### PR TITLE
feat: add feature flag and route for new quote page

### DIFF
--- a/env.template
+++ b/env.template
@@ -7,3 +7,4 @@ DATABASE_URL="postgresql://userone:passone@127.0.0.1:5432/db_one_cotizador"
 NEXT_PUBLIC_ALLOWED_ORIGINS=
 
 JWT_SECRET=
+FEATURE_NUEVA_COTIZACION=true

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,9 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  env: {
+    FEATURE_NUEVA_COTIZACION: process.env.FEATURE_NUEVA_COTIZACION,
+  },
 };
 
 export default nextConfig;

--- a/src/app/(sections)/home/_feature/quote/components/QuotesList.tsx
+++ b/src/app/(sections)/home/_feature/quote/components/QuotesList.tsx
@@ -33,13 +33,13 @@ export default function QuotesList({
   const page = Number(searchParams.get("page") || 1);
   const pageSize = Number(searchParams.get("pageSize") || 10);
 
-  const [showForm, setShowForm] = useState<{
-    data?: EditQuoteDto;
-    show: "create" | "edit" | null;
-  }>({
-    data: undefined,
-    show: null,
-  });
+    const [showForm, setShowForm] = useState<{
+      data?: EditQuoteDto;
+      show: "edit" | null;
+    }>({
+      data: undefined,
+      show: null,
+    });
   const [modalState, setModalState] = useState<{
     open: boolean;
     title: string;
@@ -50,26 +50,32 @@ export default function QuotesList({
     content: null,
   });
 
-  const debouncedSearch = debounce((value: string) => {
-    const params = new URLSearchParams(searchParams.toString());
-    if (value) {
-      params.set("search", value);
-    } else {
-      params.delete("search");
-    }
+    const debouncedSearch = debounce((value: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (value) {
+        params.set("search", value);
+      } else {
+        params.delete("search");
+      }
 
-    params.set("page", "1"); // resetear página
+      params.set("page", "1"); // resetear página
 
-    router.replace(`?${params.toString()}`);
-  }, 500);
+      router.replace(`?${params.toString()}`);
+    }, 500);
 
-  // Show form Create or edit
-  const toggleShowForm = (
-    type: "create" | "edit" | null,
-    data?: EditQuoteDto
-  ) => {
-    setShowForm({ show: type, data: data });
-  };
+    const featureNewQuote = process.env.FEATURE_NUEVA_COTIZACION === "true";
+
+    // Show form Create or edit
+    const toggleShowForm = (
+      type: "create" | "edit" | null,
+      data?: EditQuoteDto
+    ) => {
+      if (type === "edit") {
+        setShowForm({ show: "edit", data });
+      } else {
+        setShowForm({ show: null, data: undefined });
+      }
+    };
 
   const handleOpenModal = (title: string, content: React.ReactNode) => {
     setModalState({
@@ -148,18 +154,20 @@ export default function QuotesList({
                   Enviar recordatorios
                 </Button>
               </Tooltip>
-              <Button
-                icon={<PlusOutlined className="cursor-pointer" />}
-                variant="solid"
-                color="primary"
-                onClick={() => setShowForm({ show: "create", data: undefined })}
-              >
-                Nueva Cotización
-              </Button>
-            </div>
-          </>
-        )}
-      </div>
+                {featureNewQuote && (
+                  <Button
+                    icon={<PlusOutlined className="cursor-pointer" />}
+                    variant="solid"
+                    color="primary"
+                    onClick={() => router.push('/quotes/new')}
+                  >
+                    Nueva Cotización
+                  </Button>
+                )}
+              </div>
+            </>
+          )}
+        </div>
 
       {!showForm.show && (
         <div className="mt-8">

--- a/src/app/(sections)/quotes/new/ClientNewQuotePage.tsx
+++ b/src/app/(sections)/quotes/new/ClientNewQuotePage.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import QuoteForm from '@/app/(sections)/home/_feature/quote/components/QuoteForm';
+import type { EditQuoteDto } from '@/schemas/quote/quote.dto';
+
+interface Props {
+  optionsProducts: { label: string; value: number }[];
+  optionsClients: { label: string; value: number }[];
+}
+
+export default function ClientNewQuotePage({ optionsProducts, optionsClients }: Props) {
+  const router = useRouter();
+
+  const handleToggle = (type: 'create' | 'edit' | null, _data?: EditQuoteDto) => {
+    if (type === null) {
+      router.push('/home?tab=quotes');
+    }
+  };
+
+  return (
+    <div className="p-4">
+      <QuoteForm
+        toggleForm={handleToggle}
+        isEdit={false}
+        optionsProducts={optionsProducts}
+        optionsClients={optionsClients}
+      />
+    </div>
+  );
+}
+

--- a/src/app/(sections)/quotes/new/page.tsx
+++ b/src/app/(sections)/quotes/new/page.tsx
@@ -1,0 +1,19 @@
+import { redirect } from 'next/navigation';
+import ClientNewQuotePage from './ClientNewQuotePage';
+import { getCompanyClientCatalog, getCompanyProductCatalog } from '@/app/(sections)/home/_actions';
+
+export default async function NewQuotePage() {
+  if (process.env.FEATURE_NUEVA_COTIZACION !== 'true') {
+    redirect('/home?tab=quotes');
+  }
+
+  const optionsProducts = await getCompanyProductCatalog(1);
+  const optionsClients = await getCompanyClientCatalog(1);
+
+  return (
+    <ClientNewQuotePage
+      optionsProducts={optionsProducts}
+      optionsClients={optionsClients}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add FEATURE_NUEVA_COTIZACION flag to config
- create full page for creating quotes
- gate dashboard button behind feature flag

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5ee75de7483258607d023f3b439a1